### PR TITLE
Including the new keyword when instantiating the Map

### DIFF
--- a/lib/parsers/config_parser_yaml.dart
+++ b/lib/parsers/config_parser_yaml.dart
@@ -13,6 +13,6 @@ class YamlConfigParser implements ConfigParser {
     completer.complete(map);
 
     return completer.future
-        .then((val) => val.map((k, v) => MapEntry(k.toString(), v)));
+        .then((val) => val.map((k, v) => new MapEntry(k.toString(), v)));
   }
 }


### PR DESCRIPTION
Hi @MarkOSullivan94 - if you merge in this change I believe that your dart_config repository will work for Dart 2.1 as well as 2.0